### PR TITLE
markup & css updates (mobile)

### DIFF
--- a/theme/index.php
+++ b/theme/index.php
@@ -1,25 +1,31 @@
 <!doctype html>
 <html lang="en">
 	<head>
-		<title>Spigot</title>
-		<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<link href='http://fonts.googleapis.com/css?family=Open+Sans:300|Roboto+Slab:300' rel='stylesheet'>
-		<link href="<?php echo the_stylesheet(); ?>" rel="stylesheet">
+		<title>Spigot - Zen RSS Reader</title>
+		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<link href='http://fonts.googleapis.com/css?family=Open+Sans:300|Roboto+Slab:300' rel='stylesheet' />
+		<link href="<?php echo the_stylesheet(); ?>" rel="stylesheet" />
 	</head>
 	<body>
-		<div class="wrap">
-			<?php while(have_feed()) : thefeed() ?>
-					<div class="item">
-						<a href="<?php echo the_link(); ?>"><h1><?php echo the_title(); ?></h1></a>
-						<h2 class="date"><?php echo the_date(); ?></h2>
-						<p>
-							<?php echo the_description(); ?>
-						</p>
-					</div>
-			<?php endwhile; ?>
+		<div class="wrap" role="main">
+			<ul class="clean-list">
+				<?php while(have_feed()) : thefeed() ?>
+						<li class="item">
+							<article role="article">
+								<header>
+									<a href="<?php echo the_link(); ?>"><h1><?php echo the_title(); ?></h1></a>
+									<p class="date"><?php echo the_date(); ?></p>
+								</header>
+
+								<?php echo the_description(); ?>
+
+							</article>
+						</li>
+				<?php endwhile; ?>
+			</ul>
 		</div>
-		<footer>
+		<footer role="contentinfo">
 			<div class="pagination"><?php pagination(); ?></div>
 			<a href="https://github.com/Codingbean/Spigot">Spigot</a>
 		</footer>

--- a/theme/style.css
+++ b/theme/style.css
@@ -1,8 +1,17 @@
+*, *:before, *:after {
+	box-sizing: border-box;
+}
+
 body {
 	background-color: #FAFAFA;
 	font-family: 'Open Sans', sans-serif;
 	font-weight: 300;
 	line-height: 1.65em;
+	margin: 0;
+}
+
+header, footer {
+	display: block;
 }
 
 footer {
@@ -71,13 +80,25 @@ a:hover>h1, a:active>h1 {
 	margin: 0 auto;
 	max-width: 650px;
 	min-width: 300px;
-	padding-top: 4em;
+	overflow: hidden;
+	padding: 4em 2em;
+}
+
+.iframe {
+	max-width: 100%;
+}
+
+.clean-list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
 }
 
 .item {
 	border-bottom: 1px solid #e0e0e0;
 	margin-bottom: 3em;
 	padding-bottom: 2em;
+	overflow: auto;
 }
 
 .item td {


### PR DESCRIPTION
update css to make for better mobile layout, and don't allow article elements to extend outside of the viewport / creating horizontal scrolling.

if the contents of an 'item' extend horizontally beyond the viewport, an overflow: auto; has been set in place, so that item can be scrolled individually of the rest of the document.

Convert article lead-in listings from divs to ul > li > article

add appropriate aria roles and slight modifications to the markup to be more semantically correct.
